### PR TITLE
Add a space to typo type.

### DIFF
--- a/commit-types.json
+++ b/commit-types.json
@@ -32,7 +32,7 @@
       "description": "Internationalization and localization.",
       "title": "Internationalization"
     },
-    "✏️ typo": {
+    "✏️  typo": {
       "description": "Fixing typos.",
       "title": "Typos"
     },


### PR DESCRIPTION
铅笔 emoji ✏️ 比其他 emoji 小一个字符位置，终端显示逼死强迫症，你赶紧 merge 然后 update 一下 npm @xiaoxiangmoe 